### PR TITLE
Add databricks_business_erd_dashboard_single_cell starter script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Test01
+
+ไฟล์หลักสำหรับทำงานต่อ:
+- `databricks_business_erd_dashboard_single_cell.py`
+
+เริ่มต้นรันได้ด้วย:
+```bash
+python databricks_business_erd_dashboard_single_cell.py
+```

--- a/databricks_business_erd_dashboard_single_cell.py
+++ b/databricks_business_erd_dashboard_single_cell.py
@@ -1,0 +1,80 @@
+"""
+Databricks Business ERD Dashboard (single-cell style script)
+
+This standalone file is intentionally self-contained so it can be pasted into
+one Databricks notebook cell or run as a local Python script.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class TableNode:
+    """Represents a table in an ERD graph."""
+
+    name: str
+    domain: str
+
+
+@dataclass(frozen=True)
+class RelationEdge:
+    """Represents a relationship between two tables."""
+
+    source: str
+    target: str
+    relation: str = "FK"
+
+
+def sample_nodes() -> list[TableNode]:
+    """Initial sample dataset for dashboard development."""
+    return [
+        TableNode("dim_customer", "sales"),
+        TableNode("dim_product", "sales"),
+        TableNode("fact_order", "sales"),
+        TableNode("fact_payment", "finance"),
+    ]
+
+
+def sample_edges() -> list[RelationEdge]:
+    """Initial sample relationships for dashboard development."""
+    return [
+        RelationEdge("fact_order", "dim_customer"),
+        RelationEdge("fact_order", "dim_product"),
+        RelationEdge("fact_payment", "fact_order"),
+    ]
+
+
+def to_mermaid(nodes: Iterable[TableNode], edges: Iterable[RelationEdge]) -> str:
+    """Render ERD-like relationships in Mermaid flowchart syntax."""
+    lines: list[str] = ["flowchart LR"]
+
+    seen: set[str] = set()
+    for node in nodes:
+        if node.name not in seen:
+            lines.append(f"    {node.name}[{node.name}\\n({node.domain})]")
+            seen.add(node.name)
+
+    for edge in edges:
+        lines.append(f"    {edge.source} -->|{edge.relation}| {edge.target}")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    nodes = sample_nodes()
+    edges = sample_edges()
+    diagram = to_mermaid(nodes, edges)
+
+    print("Databricks Business ERD Dashboard (Starter)")
+    print("=" * 45)
+    print(f"tables: {len(nodes)}")
+    print(f"relations: {len(edges)}")
+    print("\nMermaid diagram:\n")
+    print(diagram)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a self-contained starter script to continue ERD dashboard development in this repository since the original source project was not available.
- Make it easy to iterate locally or in a Databricks notebook by including a runnable example and basic sample data.

### Description
- Added `databricks_business_erd_dashboard_single_cell.py` which defines `TableNode` and `RelationEdge` dataclasses, `sample_nodes` and `sample_edges` generators, a `to_mermaid` renderer, and an executable `main` for quick iteration.
- Updated `README.md` to point at the new starter file and document how to run it.
- The script is self-contained and prints a simple Mermaid-compatible flowchart representing tables and relationships for immediate validation.

### Testing
- Ran `python -m py_compile databricks_business_erd_dashboard_single_cell.py` which completed successfully with no syntax errors.
- Ran `python databricks_business_erd_dashboard_single_cell.py` which printed the expected summary and Mermaid diagram showing `tables: 4` and `relations: 3`.
- Ran `git status --short` to confirm repository state, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb6ff000c83279f310e0373cd550b)